### PR TITLE
issue-157

### DIFF
--- a/ansible/roles/kind/README.adoc
+++ b/ansible/roles/kind/README.adoc
@@ -18,7 +18,11 @@ TODO
 
 ```bash
 ansible-playbook ./kubernetes/ansible/k8s-misc.yml -t kind
-ansible-playbook ./kubernetes/ansible/k8s-local.yml -t kind -i ./ansible/inventory/local --connection=local
+```
+
+To execute on the host machine, the playbook
+```bash
+ansible-playbook ./kubernetes/ansible/k8s-misc.yml -t kind --connection=local -e override_host=localhost
 ```
 
 === License

--- a/ansible/roles/kind/tasks/install.yml
+++ b/ansible/roles/kind/tasks/install.yml
@@ -27,9 +27,9 @@
   register: mktemp
   changed_when: False
 
-- name: Copy the kind config file
-  copy:
-    src: files/config.yml
+- name: Populate the kind config file from the template
+  template:
+    src: config.yml.j2
     dest: "{{ mktemp.stdout }}/config.yml"
 
 - name: Create Kubernetes Cluster using the config file

--- a/ansible/roles/kind/templates/config.yml.j2
+++ b/ansible/roles/kind/templates/config.yml.j2
@@ -17,9 +17,9 @@ nodes:
         containerPort: 443
         hostPort: 443
         listenAddress: 0.0.0.0
-    containerdConfigPatches:
-      - |-
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:{{registry_port}}"]
-          endpoint = ["http://{{registry_name}}:{{registry_port}}"]
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{registry_name}}:{{registry_port}}"]
-          endpoint = ["http://{{registry_name}}:{{registry_port}}"]
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:{{ registry_port }}"]
+      endpoint = ["http://{{ registry_name }}:{{ registry_port }}"]
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ registry_name }}:{{ registry_port }}"]
+      endpoint = ["http://{{ registry_name }}:{{ registry_port }}"]


### PR DESCRIPTION
- Use a jinja template to populate the kind config file
- Add `containerdConfigPatches` to the kind cluster config to configure the `plugins."io.containerd.grpc.v1.cri".registry.mirrors` fo the docker registry

#167 