### PR TITLE
Chore: Add pre-tasks to install python3 and pip3 on the target machin…

### DIFF
--- a/ansible/roles/kind/tasks/main.yml
+++ b/ansible/roles/kind/tasks/main.yml
@@ -1,3 +1,6 @@
+- name: Check required packages needed by the modules
+  include_tasks: packages.yml
+
 - include_tasks: install.yml
   when: not remove | bool
 

--- a/ansible/roles/kind/tasks/packages.yml
+++ b/ansible/roles/kind/tasks/packages.yml
@@ -1,0 +1,6 @@
+- name: Install module dependencies
+  pip:
+    name:
+      - docker==4.2.1
+      - openshift==0.11.2
+    executable: pip3

--- a/kubernetes/ansible/k8s-misc.yml
+++ b/kubernetes/ansible/k8s-misc.yml
@@ -6,6 +6,19 @@
   vars:
     client_tool: kubectl
 
+  pre_tasks:
+    - name: Install Python3 if missing
+      yum:
+        name:
+        - python3
+        - python3-pip
+        state: present
+        use_backend: yum
+      become: yes
+      vars:
+        ansible_python_interpreter: /usr/bin/python
+      tags: always
+
   roles:
     - { role: 'k8s_cluster',   tags: 'k8s_cluster'}
     - { role: 'k8s_config',   tags: 'k8s_config'}


### PR DESCRIPTION
- Add pre-tasks to install python3 and pip3 on the target machine if not installed. 
- Deploy the missing packages needed by the ansible modules: docker, k8s if not there
- Fix the issue about "The Python 2 bindings for rpm are needed for this module" reported by yum by setting the var `ansible_python_interpreter =/usr/bin/python`
- Fix the issue to use the correct `pip` executable 

#169 