### PR TITLE
fix: removed the authorized key and added cleanup for known hosts

### DIFF
--- a/ansible/roles/hetzner/create_server/tasks/main.yml
+++ b/ansible/roles/hetzner/create_server/tasks/main.yml
@@ -64,18 +64,12 @@
     state: absent
   when: "hcloud_server_create_res.rc == 0"
 
-#- name: "Add the server to the known_hosts file"
-#  known_hosts:
-#    path: "{{ user_home + '/.ssh/known_hosts' }}"
-#    name: "{{ ip_address }}"
-#    key: "{{ ip_address }} {{ ssh_public_key }}"
-#    state: present
-#  when: "hcloud_server_create_res.rc == 0"
-
-- name: "Add server key to local authorized keys"
-  authorized_key:
-    user: "{{ ansible_user }}"
-    key: "{{ hetzner_public_key }}"
-  when: "hcloud_server_create_res.rc == 0 or 'uniqueness_error' in hcloud_server_create_res.stderr"
+# - name: "Add the server to the known_hosts file"
+#   known_hosts:
+#     path: "{{ user_home + '/.ssh/known_hosts' }}"
+#     name: "{{ ip_address }}"
+#     key: "{{ ip_address }} {{ ssh_public_key }}"
+#     state: present
+#   when: "hcloud_server_create_res.rc == 0"
 
 ...

--- a/ansible/roles/hetzner/delete_server/tasks/main.yml
+++ b/ansible/roles/hetzner/delete_server/tasks/main.yml
@@ -1,4 +1,16 @@
 ---
+- name: "Obtain user home"
+  set_fact:
+    user_home: "{{ lookup('env','HOME') }}"
+
+- name: "Remove the server from the known_hosts file"
+  known_hosts:
+    path: "{{ user_home + '/.ssh/known_hosts' }}"
+    name: "{{ ip_address }}"
+    state: absent
+  when: "ip_address is defined"
+  failed_when: false
+
 # tasks for hetzner/delete_server
 - name: Delete cloud server
   shell: "hcloud server delete {{ vm_name }}"


### PR DESCRIPTION
The `authorized_key` doesn't apply in this case. 
Added cleanup for the `known_hosts` file when the server is removed

Closes #192