### PR TITLE
fix: if apiserver_address is defined but empty use the ansible_ssh_host as ingress host

### DIFF
--- a/ansible/roles/k8s_dashboard/tasks/install.yml
+++ b/ansible/roles/k8s_dashboard/tasks/install.yml
@@ -4,7 +4,7 @@
 
 - set_fact:
     k8s_dashboard_ingress_host: "{{ ansible_ssh_host }}.nip.io"
-  when: apiserver_address is undefined
+  when: (apiserver_address is undefined) or (apiserver_address|length == 0) 
 
 - set_fact:
     k8s_dashboard_ingress_host: "{{ apiserver_address }}.nip.io"


### PR DESCRIPTION
In the `k8s_dashboard` installation, default to the `ansible_ssh_host` as ingress host both if `apiserver_address` is undefined or empty.