### PR TITLE
Improve docker registry

### DIFF
--- a/ansible/roles/docker_registry/defaults/main.yml
+++ b/ansible/roles/docker_registry/defaults/main.yml
@@ -3,3 +3,5 @@ remove: false
 registry:
   service_name: kube-registry
   namespace: kube-system
+  user: admin
+  pwd: snowdrop

--- a/ansible/roles/docker_registry/defaults/main.yml
+++ b/ansible/roles/docker_registry/defaults/main.yml
@@ -2,6 +2,6 @@ remove: false
 
 registry:
   service_name: kube-registry
-  namespace: kube-system
+  namespace: infra
   user: admin
   pwd: snowdrop

--- a/ansible/roles/docker_registry/tasks/generate_server_crt.yml
+++ b/ansible/roles/docker_registry/tasks/generate_server_crt.yml
@@ -70,21 +70,19 @@
     state: directory
   become: yes
 
-- name: Creates Registry docker Certs that we will mount
-  file:
-    path: /root/docker-certs
-    state: directory
-  become: yes
-
 - name: "Add the certificate populated for the registry to the certificates supported by the docker daemon"
   shell: |
     cp server.crt /etc/docker/certs.d/{{ registry.service_name}}.{{ registry.namespace }}.svc:5000/
   become: yes
 
-- name: Copy the self signed Certificate and Private keys under the folder that we will mount within the docker registry
+- name: "Add the certificate populated for the registry to the certificates directory watched by containerd"
   shell: |
-    cp server.crt /root/docker-certs
-    cp server-key.pem /root/docker-certs
+     cp server.crt /etc/pki/tls/certs
+  become: yes
+
+- name: Create a secret to mount the self signed Certificate and Private key
+  shell: |
+    {{ client_tool }} --kubeconfig={{ ansible_user_dir }}/.kube/config create secret generic cert-key -n {{ registry.namespace }} --from-file=server.crt --from-file=server-key.pem
   become: yes
 
 - name: Add IP address of the Registry to the /etc/hosts/file

--- a/ansible/roles/docker_registry/tasks/install.yml
+++ b/ansible/roles/docker_registry/tasks/install.yml
@@ -1,9 +1,6 @@
 - name: Create the infra k8s namespace
-  k8s:
-    name: {{ registry.namespace }}
-    api_version: v1
-    kind: Namespace
-    state: present
+  shell: |
+     {{ client_tool }} --kubeconfig={{ ansible_user_dir }}/.kube/config create ns {{ registry.namespace }} --dry-run=client -o yaml | {{ client_tool }} --kubeconfig={{ ansible_user_dir }}/.kube/config apply -f -
 
 - name: Generate PVC file
   template:

--- a/ansible/roles/docker_registry/tasks/install.yml
+++ b/ansible/roles/docker_registry/tasks/install.yml
@@ -8,6 +8,17 @@
     src: service.yml.j2
     dest: /tmp/service.yml
 
+- name: install the latest version of httpd-tools
+  yum:
+    name: httpd-tools
+    state: latest
+  become: yes
+
+- name: Create htpasswd file
+  shell: |
+    touch /tmp/htpasswd
+    htpasswd -Bbc /tmp/htpasswd {{ registry.user }} {{ registry.pwd }}
+
 - name: Install PVC
   shell: |
     {{ client_tool }} --kubeconfig={{ ansible_user_dir }}/.kube/config apply -f /tmp/pvc.yml -n {{ registry.namespace }}
@@ -15,6 +26,11 @@
 - name: Install Service
   shell: |
     {{ client_tool }} --kubeconfig={{ ansible_user_dir }}/.kube/config apply -f /tmp/service.yml -n {{ registry.namespace }}
+
+- name: Create the secret containing the htpasswd file
+  shell: |
+    {{ client_tool }} --kubeconfig={{ ansible_user_dir }}/.kube/config create secret generic htpasswd -n {{ registry.namespace }} --from-file=/tmp/htpasswd
+  become: yes
 
 - name: Generate Server crt
   import_tasks: generate_server_crt.yml

--- a/ansible/roles/docker_registry/tasks/install.yml
+++ b/ansible/roles/docker_registry/tasks/install.yml
@@ -1,3 +1,10 @@
+- name: Create the infra k8s namespace
+  k8s:
+    name: {{ registry.namespace }}
+    api_version: v1
+    kind: Namespace
+    state: present
+
 - name: Generate PVC file
   template:
     src: pvc.yml.j2

--- a/ansible/roles/docker_registry/tasks/remove.yml
+++ b/ansible/roles/docker_registry/tasks/remove.yml
@@ -1,6 +1,12 @@
+- name: Delete the htpasswd file
+  file:
+    path: /tmp/htpasswd
+    state: absent
 - name: Uninstall Docker Registry
   shell: |
     {{ client_tool }} --kubeconfig={{ ansible_user_dir }}/.kube/config delete ReplicationController/{{ registry.service_name}} -n {{ registry.namespace }}
     {{ client_tool }} --kubeconfig={{ ansible_user_dir }}/.kube/config delete pvc/{{ registry.service_name}}-pvc               -n {{ registry.namespace }}
     {{ client_tool }} --kubeconfig={{ ansible_user_dir }}/.kube/config delete svc/{{ registry.service_name}}                   -n {{ registry.namespace }}
+    {{ client_tool }} --kubeconfig={{ ansible_user_dir }}/.kube/config delete secret/cert-key                                  -n {{ registry.namespace }}
+    {{ client_tool }} --kubeconfig={{ ansible_user_dir }}/.kube/config delete secret/htpasswd                                  -n {{ registry.namespace }}
   ignore_errors: true

--- a/ansible/roles/docker_registry/templates/cfssl.json.j2
+++ b/ansible/roles/docker_registry/templates/cfssl.json.j2
@@ -4,7 +4,7 @@
     "{{ registry.service_name }}.{{ registry.namespace }}.svc.cluster",
     "{{ registry.service_name }}.{{ registry.namespace }}.svc.cluster.local",
     "{{ ansible_default_ipv4.address }}.nip.io",
-    "{{ ansible_default_ipv4.address }}"
+    "{{ ansible_default_ipv4.address }}",
     "{{ registry_ip_address.stdout }}",
   ],
   "CN": "{{ registry.service_name}}",

--- a/ansible/roles/docker_registry/templates/cfssl.json.j2
+++ b/ansible/roles/docker_registry/templates/cfssl.json.j2
@@ -5,18 +5,18 @@
     "{{ registry.service_name }}.{{ registry.namespace }}.svc.cluster.local",
     "{{ ansible_default_ipv4.address }}.nip.io",
     "{{ ansible_default_ipv4.address }}",
-    "{{ registry_ip_address.stdout }}",
+    "{{ registry_ip_address.stdout }}"
   ],
-  "CN": "{{ registry.service_name}}",
+  "CN": "{{ registry.service_name }}",
   "key": {
     "algo": "ecdsa",
     "size": 256
   },
   "names": [{
-    "C": "BE",
+    "C":  "BE",
     "ST": "Namur",
-    "L": "Florennes",
-    "O": "Red Hat Middleware",
+    "L":  "Florennes",
+    "O":  "Red Hat Middleware",
     "OU": "Snowdrop"
   }]
 }

--- a/ansible/roles/docker_registry/templates/cfssl.json.j2
+++ b/ansible/roles/docker_registry/templates/cfssl.json.j2
@@ -3,7 +3,9 @@
     "{{ registry.service_name }}.{{ registry.namespace }}.svc",
     "{{ registry.service_name }}.{{ registry.namespace }}.svc.cluster",
     "{{ registry.service_name }}.{{ registry.namespace }}.svc.cluster.local",
-    "{{ registry_ip_address.stdout }}"
+    "{{ ansible_default_ipv4.address }}.nip.io",
+    "{{ ansible_default_ipv4.address }}"
+    "{{ registry_ip_address.stdout }}",
   ],
   "CN": "{{ registry.service_name}}",
   "key": {

--- a/ansible/roles/docker_registry/templates/replication-controller.yml.j2
+++ b/ansible/roles/docker_registry/templates/replication-controller.yml.j2
@@ -35,11 +35,19 @@ spec:
               value: /certs/server.crt
             - name: REGISTRY_HTTP_TLS_KEY
               value: /certs/server-key.pem
+            - name: REGISTRY_AUTH
+              value: htpasswd
+            - name: REGISTRY_AUTH_HTPASSWD_REALM
+              value: Registry Realm
+            - name: REGISTRY_AUTH_HTPASSWD_PATH
+              value: /auth/htpasswd
           volumeMounts:
             - name: image-store
               mountPath: /var/lib/registry
             - name: certs
               mountPath: /certs
+            - name: auth
+              mountPath: /auth
           ports:
             - containerPort: 5000
               name: registry
@@ -49,5 +57,8 @@ spec:
           persistentVolumeClaim:
             claimName: kube-registry-pvc
         - name: certs
-          hostPath:
-            path: /root/docker-certs
+          secret:
+            secretName: cert-key
+        - name: auth
+          secret:
+            secretName: htpasswd

--- a/ansible/roles/docker_registry/templates/service.yml.j2
+++ b/ansible/roles/docker_registry/templates/service.yml.j2
@@ -4,14 +4,17 @@ metadata:
   name: {{ registry.service_name}}
   namespace: {{ registry.namespace }}
   labels:
-    k8s-app: {{ registry.service_name}}
+    k8s-app: {{ registry.service_name }}
     kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "KubeRegistry"
+    kubernetes.io/name: {{ registry.service_name }}
 spec:
-  type: ClusterIP
-  selector:
-    k8s-app: {{ registry.service_name}}
+  {% if registry_nodePort is defined %}type: NodePort
+  {% else %}type: ClusterIP
+{% endif %}selector:
+    k8s-app: {{ registry.service_name }}
   ports:
     - name: registry
       port: 5000
       protocol: TCP
+      {% if registry_nodePort is defined %}nodePort: {{ registry_nodePort }}
+      {% endif %}

--- a/kubernetes/ansible/k8s-misc.yml
+++ b/kubernetes/ansible/k8s-misc.yml
@@ -24,3 +24,6 @@
     - { role: 'helm',   tags: 'helm'}
     # Kubernetes SIG Kind project/tool which allows to install a k8s cluster without kubeadm, kubelet
     - { role: 'kind',   tags: 'kind'}
+
+    # Role created for testing purposes
+    - { role: 'test',   tags: 'test'}


### PR DESCRIPTION
- See tickets #195, #196, #197
- Enable htpasswd auth
- Mount the certs and auth files using secrets
- Remove hostPath access
- Add IP address to allow a user to access the docker registry remotely

Closes #195 
Closes #196
Closes #197 