### PR TITLE
feat: Apply git pull and push before each passwordstore playbook. Adapt to Ansible 2.10

### DIFF
--- a/ansible/playbook/passstore_controller_inventory.yml
+++ b/ansible/playbook/passstore_controller_inventory.yml
@@ -1,25 +1,33 @@
+---
+# Required variables:
+#  . vm_name: Name of the vm
+#  . pass_provider: provider in the passstore project [hetzner]
+#  . k8s_type: Kubernetes host type [masters,nodes], empty for no k8s installation
+#  . k8s_version: Kubernetes version [115,116], empty for no k8s installation
 - name: "Generate inventory files on the controller"
   hosts: localhost
   gather_facts: no
-  vars_prompt:
-    - name: vm_name
-      prompt: vm name
-      private: no
-      #when: " vm_name is not defined "
-    - name: pass_provider
-      prompt: Passwordstore Provider [hetzner,openstack,...]
-      private: no
-      #when: " pass_provider is not defined "
-    - name: k8s_type
-      prompt: Kubernetes host type [masters,nodes], empty for no k8s installation
-      private: no
-      #when: " k8s_type is not defined "
-    - name: k8s_version
-      prompt: Kubernetes version [115,116], empty for no k8s installation
-      private: no
-      #when: " k8s_type is not defined "
 
   pre_tasks:
+    - name: "Validate required variables"
+      assert:
+        that:
+          - "vm_name is defined"
+          - "pass_provider is defined"
+          - "k8s_type is defined"
+          - "k8s_version is defined"
+        fail_msg: 
+          - "Required parameters:"
+          - "  vm_name: Name of the vm"
+          - "  pass_provider: provider in the passstore project [hetzner]"
+          - "  k8s_type: Kubernetes host type [masters,nodes], empty for no k8s installation"
+          - "  k8s_version: Kubernetes version [115,116], empty for no k8s installation"
+
+    - name: "Pull pass git database"
+      shell: "git pull"
+      args:
+        chdir: "{{ lookup('env', 'PASSWORD_STORE_DIR') }}"
+
     - name: Check k8s_type value
       fail:
         msg: "Invalid k8s type {{ k8s_type }}. Should be in [masters,nods]"
@@ -76,3 +84,10 @@
         - "k8s_{{ k8s_version }}"
       when: "k8s_type is defined and k8s_type | length > 0 and k8s_version is defined and k8s_version | length > 0"
       tags: [always]
+
+  post_tasks:
+    - name: "Push changes to the pass git database"
+      shell: "git push"
+      args:
+        chdir: "{{ lookup('env', 'PASSWORD_STORE_DIR') }}"
+...

--- a/ansible/playbook/passstore_controller_inventory_remove.yml
+++ b/ansible/playbook/passstore_controller_inventory_remove.yml
@@ -1,21 +1,24 @@
 ---
-# file: clear_local_inventory_configuration.yml
+# file: passstore_controller_inventory_remove.yml
 # Required variables:
 #  . vm_name: Name of the vm
 #  . pass_provider: provider in the passstore project [hetzner]
 - name: Delete local inventory configuration
   hosts: localhost
   gather_facts: no
-  vars_prompt:
-    - name: vm_name
-      prompt: vm name
-      private: no
-      when: " vm_name is not defined "
-      
-    - name: pass_provider
-      prompt: Provider [hetzner,...]
-      private: no
-      when: "pass_provider is not defined "
+
+  pre_tasks:
+    - name: "Validate required variables"
+      assert:
+        that:
+          - "vm_name is defined"
+          - "pass_provider is defined"
+        fail_msg: "'vm_name' and 'pass_provider' must be defined"
+
+    - name: "Pull pass git database"
+      shell: "git pull"
+      args:
+        chdir: "{{ lookup('env', 'PASSWORD_STORE_DIR') }}"
 
   tasks:
     - name: Remove passstore entries
@@ -28,4 +31,11 @@
       shell: "rm -f ~/.ssh/id_rsa_snowdrop_{{ pass_provider }}_{{ vm_name }}*"
       changed_when: "pass_rm_res.rc == 0"
       failed_when: "false"
+
+  post_tasks:
+    - name: "Push changes to the pass git database"
+      shell: "git push"
+      args:
+        chdir: "{{ lookup('env', 'PASSWORD_STORE_DIR') }}"
+
 ...

--- a/ansible/playbook/passstore_manage_host_groups.yml
+++ b/ansible/playbook/passstore_manage_host_groups.yml
@@ -1,21 +1,27 @@
+---
 - name: "Generate inventory files on the controller"
   hosts: localhost
   gather_facts: no
-  vars_prompt:
-    - name: vm_name
-      prompt: vm name
-      private: no
-      when: "vm_name is not defined"
-    - name: group_name
-      prompt: Group name
-      private: no
-      when: "group_name is not defined"
-    - name: operation
-      prompt: Operation [add,remove]
-      private: no
-      when: "operation is not defined"
 
   pre_tasks:
+    - name: "Validate required variables"
+      assert:
+        that:
+          - "vm_name is defined"
+          - "group_name is defined"
+          - "operation is defined"
+          - "operation == 'add' or operation == 'remove'"
+        fail_msg: 
+          - "Required parameters:"
+          - "  vm_name: Name of the vm"
+          - "  group_name: "
+          - "  operation: Operation to be executed, either 'add' or 'remove'"
+
+    - name: "Pull pass git database"
+      shell: "git pull"
+      args:
+        chdir: "{{ lookup('env', 'PASSWORD_STORE_DIR') }}"
+
     - name: Get vm host vars
       set_fact:
         my_hostvars: "{{ hostvars[vm_name] }}"
@@ -71,4 +77,9 @@
       when: "operation == 'remove' "
       tags: [always]
 
+  post_tasks:
+    - name: "Push changes to the pass git database"
+      shell: "git push"
+      args:
+        chdir: "{{ lookup('env', 'PASSWORD_STORE_DIR') }}"
 ...

--- a/ansible/roles/passstore/ansible_inventory/tasks/add_variable.yml
+++ b/ansible/roles/passstore/ansible_inventory/tasks/add_variable.yml
@@ -1,8 +1,19 @@
 ---
+- name: "Pull pass git database"
+  shell: "git pull"
+  args:
+    chdir: "{{ lookup('env', 'PASSWORD_STORE_DIR') }}"
+
 - name: "Set the pass URL"
   include_tasks: "set_pass_facts.yml"
 
 - name: "Set pass fact {{var_value}}"
   set_fact:
     applied_var_data: "{{ query('passwordstore', pass_l3_route + '/' + var_name + ' create=True overwrite=true userpass=' + var_value)[0] }}"
+
+- name: "Push changes to the pass git database"
+  shell: "git push"
+  args:
+    chdir: "{{ lookup('env', 'PASSWORD_STORE_DIR') }}"
+    
 ...

--- a/hetzner/ansible/hetzner-create-server.yml
+++ b/hetzner/ansible/hetzner-create-server.yml
@@ -4,18 +4,29 @@
 - name:  Create hetzner server
   hosts: localhost
   gather_facts: yes
-  vars_prompt:
-    - name: vm_name
-      prompt: Name of the VM being created [vm_name]
-      private: no
-      when: " vm_name is not defined "
+  # vars_prompt:
+  #   - name: vm_name
+  #     prompt: Name of the VM being created [vm_name]
+  #     private: no
 
-    - name: salt_text
-      prompt: Salt
-      private: yes
-      when: " salt_text is not defined "
+  #   - name: salt_text
+  #     prompt: Salt
+  #     private: yes
 
   pre_tasks:
+
+    - name: "Validate required variables"
+      assert:
+        that:
+          - "vm_name is defined"
+          - "salt_text is defined"
+        fail_msg: "'vm_name' and 'salt_text' must be defined"
+
+    - name: "Validate host is initialized in passwordstore"
+      assert:
+        that:
+          - "hostvars[vm_name] is defined"
+        fail_msg: "Host must be initialized in the passwordstore. Run 'ansible-playbook ansible/playbook/passstore_controller_inventory.yml -e vm_name={{ vm_name }} -e pass_provider=hetzner'"
 
     - name: Get vm host vars
       set_fact:
@@ -25,6 +36,11 @@
       set_fact:
         hetzner_context_name: "snowdrop"
       when: hetzner_context_name is not defined
+
+    - name: "Pull pass git database"
+      shell: "git pull"
+      args:
+        chdir: "{{ lookup('env', 'PASSWORD_STORE_DIR') }}"
 
   tasks:
     - name: "Actuvate hetzner context"
@@ -52,13 +68,17 @@
         var_value: "{{ ip_address }}"
 
   post_tasks:
-
     - name: Refresh the inventory
       meta: refresh_inventory
 
     - name: Get vm host vars
       set_fact:
         my_hostvars: "{{ hostvars[vm_name] }}"
+
+    - name: "Push changes to the pass git database"
+      shell: "git push"
+      args:
+        chdir: "{{ lookup('env', 'PASSWORD_STORE_DIR') }}"
 
 - name:  Wait for the VM to boot and we can ssh
   hosts: "{{ vm_name }}"
@@ -73,4 +93,5 @@
     - name: "DON'T FORGET TO SECURE YOUR SERVER"
       debug:
         msg: "Trying to start start server securization automatically For manual execution: $ ansible-playbook ansible/playbook/sec_host.yml -e vm_name={{ vm_name }} -e provider=hetzner"
+
 ...

--- a/hetzner/ansible/hetzner-delete-server.yml
+++ b/hetzner/ansible/hetzner-delete-server.yml
@@ -19,10 +19,23 @@
         hetzner_context_name: "snowdrop"
       when: hetzner_context_name is not defined
 
+    - name: "Pull pass git database"
+      shell: "git pull"
+      args:
+        chdir: "{{ lookup('env', 'PASSWORD_STORE_DIR') }}"
+
   roles:
     - role: hetzner/activate_context
       context_name: "{{ hetzner_context_name }}"
 
     - role: hetzner/delete_server
       vm_name: "{{ vm_name }}"
+
+  post_tasks:
+
+    - name: "Push changes to the pass git database"
+      shell: "git push"
+      args:
+        chdir: "{{ lookup('env', 'PASSWORD_STORE_DIR') }}"
+
 ...


### PR DESCRIPTION
At the start and finish of the playbooks that use/update the passwordstore a `git pull` (at the beginning) and a `git push` (at the end) is being executed to force synchronization with the git repository. The goal is reducing conflicts.

Since the tests are being made with Ansible 2.10 the playbooks needed to be adapted to this version which requires the removal of the `when` parameter of the `vars_prompt`. One step further, so previous versions aren't affected, `vars_prompt`' have been replaced by the verification of all the `vars_prompt` parameters with an `assert` validating them.

An example of such `assert` is the following:
```
TASK [Validate required variables] **********************************************************************************************************
Thursday 11 March 2021  11:40:04 +0100 (0:00:00.020)       0:00:00.020 ******** 
fatal: [localhost]: FAILED! => {
    "assertion": "k8s_type is defined",
    "changed": false,
    "evaluated_to": false,
    "msg": [
        "Required parameters:",
        "  vm_name: Name of the vm",
        "  pass_provider: provider in the passstore project [hetzner]",
        "  k8s_type: Kubernetes host type [masters,nodes], empty for no k8s installation",
        "  k8s_version: Kubernetes version [115,116], empty for no k8s installation"
    ]
}
```

Closes #199 