### PR TITLE
Issue - 265

### DIFF
--- a/ansible/roles/k8s_issuer_certificate/tasks/install.yml
+++ b/ansible/roles/k8s_issuer_certificate/tasks/install.yml
@@ -3,11 +3,13 @@
 
 - set_fact:
     renewBefore: 8759h # 1 year - 1h
+    duration: 8760h
     letsencrypt_url: https://acme-{{ letsencrypt_env }}-v02.api.letsencrypt.org/directory
   when: letsencrypt_env == "staging"
 
 - set_fact:
     renewBefore: 2136h # 3 months - 24h
+    duration: 2190h
     letsencrypt_url: https://acme-v02.api.letsencrypt.org/directory
   when: letsencrypt_env == "prod"
 

--- a/ansible/roles/k8s_issuer_certificate/templates/certificate.yml.j2
+++ b/ansible/roles/k8s_issuer_certificate/templates/certificate.yml.j2
@@ -10,7 +10,7 @@ spec:
   renewBefore: {{ renewBefore }}
   privateKey:
     size: 2048
-    algorithm: rsa
+    algorithm: RSA
   issuerRef:
     kind: Issuer
     name: letsencrypt-{{ letsencrypt_env }}-{{ item.name }}

--- a/ansible/roles/k8s_issuer_certificate/templates/certificate.yml.j2
+++ b/ansible/roles/k8s_issuer_certificate/templates/certificate.yml.j2
@@ -8,6 +8,7 @@ metadata:
   namespace: {{ item.namespace }}
 spec:
   renewBefore: {{ renewBefore }}
+  duration: {{ duration }}
   privateKey:
     size: 2048
     algorithm: RSA

--- a/ansible/roles/k8s_issuer_certificate/templates/certificate.yml.j2
+++ b/ansible/roles/k8s_issuer_certificate/templates/certificate.yml.j2
@@ -8,8 +8,9 @@ metadata:
   namespace: {{ item.namespace }}
 spec:
   renewBefore: {{ renewBefore }}
-  keySize: 2048
-  keyAlgorithm: rsa
+  privateKey:
+    size: 2048
+    algorithm: rsa
   issuerRef:
     kind: Issuer
     name: letsencrypt-{{ letsencrypt_env }}-{{ item.name }}

--- a/ansible/roles/k8s_issuer_certificate/templates/certificate.yml.j2
+++ b/ansible/roles/k8s_issuer_certificate/templates/certificate.yml.j2
@@ -1,5 +1,5 @@
 {% set dnsNameList = (item.names.split(",")) %}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ item.name }}

--- a/ansible/roles/k8s_issuer_certificate/templates/letsencrypt_issuer.yml.j2
+++ b/ansible/roles/k8s_issuer_certificate/templates/letsencrypt_issuer.yml.j2
@@ -1,5 +1,5 @@
 {% set dnsNameList = (item.names.split(",")) %}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: letsencrypt-{{ letsencrypt_env }}-{{ item.name }}


### PR DESCRIPTION
- Rename the version of the API from v1alpha2 to v1 for template files: issuer and certificate. 
- Bump the default version from 0.12 to 1.7.3 which is supported on k8s 1.17..1.19